### PR TITLE
Assert slice lengths are always > 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@ pub const MAX_LENGTH: usize = sys::MAX_LENGTH;
 ///
 /// # Panics
 ///
-/// Attempting to convert a slice longer than [`MAX_LENGTH`] to an `IoVec` will
-/// result in a panic.
+/// Attempting to convert a zero-length slice or a slice longer than
+/// [`MAX_LENGTH`] to an `IoVec` will result in a panic.
 ///
 /// [`MAX_LENGTH`]: constant.MAX_LENGTH.html
 pub struct IoVec {
@@ -56,6 +56,26 @@ pub struct IoVec {
 }
 
 impl IoVec {
+    pub fn from_bytes(slice: &[u8]) -> Option<&IoVec> {
+        if slice.len() == 0 {
+            return None
+        }
+        unsafe {
+            let iovec: &sys::IoVec = slice.into();
+            Some(mem::transmute(iovec))
+        }
+    }
+
+    pub fn from_bytes_mut(slice: &mut [u8]) -> Option<&mut IoVec> {
+        if slice.len() == 0 {
+            return None
+        }
+        unsafe {
+            let iovec: &mut sys::IoVec = slice.into();
+            Some(mem::transmute(iovec))
+        }
+    }
+
     #[deprecated(since = "0.1.0", note = "deref instead")]
     #[doc(hidden)]
     pub fn as_bytes(&self) -> &[u8] {
@@ -83,35 +103,43 @@ impl ops::DerefMut for IoVec {
     }
 }
 
+#[doc(hidden)]
 impl<'a> From<&'a [u8]> for &'a IoVec {
     fn from(bytes: &'a [u8]) -> &'a IoVec {
-        unsafe {
-            let iovec: &sys::IoVec = bytes.into();
-            mem::transmute(iovec)
-        }
+        IoVec::from_bytes(bytes)
+            .expect("this crate accidentally accepted 0-sized slices \
+                     originally but this was since discovered as a soundness \
+                     hole, it's recommended to use the `from_bytes` \
+                     function instead")
     }
 }
 
+#[doc(hidden)]
 impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
     fn from(bytes: &'a mut [u8]) -> &'a mut IoVec {
-        unsafe {
-            let iovec: &mut sys::IoVec = bytes.into();
-            mem::transmute(iovec)
-        }
+        IoVec::from_bytes_mut(bytes)
+            .expect("this crate accidentally accepted 0-sized slices \
+                     originally but this was since discovered as a soundness \
+                     hole, it's recommended to use the `from_bytes_mut` \
+                     function instead")
     }
 }
 
+#[doc(hidden)]
 impl<'a> Default for &'a IoVec {
     fn default() -> Self {
-        let b: &[u8] = Default::default();
-        b.into()
+        panic!("this implementation was accidentally provided but is \
+                unfortunately unsound, it's recommended to stop using \
+                `IoVec::default` or construct a vector with a nonzero length");
     }
 }
 
+#[doc(hidden)]
 impl<'a> Default for &'a mut IoVec {
     fn default() -> Self {
-        let b: &mut [u8] = Default::default();
-        b.into()
+        panic!("this implementation was accidentally provided but is \
+                unfortunately unsound, it's recommended to stop using \
+                `IoVec::default` or construct a vector with a nonzero length");
     }
 }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -29,6 +29,7 @@ impl IoVec {
 
 impl<'a> From<&'a [u8]> for &'a IoVec {
     fn from(src: &'a [u8]) -> Self {
+        assert!(src.len() > 0);
         unsafe {
             mem::transmute(libc::iovec {
                 iov_base: src.as_ptr() as *mut _,
@@ -40,6 +41,7 @@ impl<'a> From<&'a [u8]> for &'a IoVec {
 
 impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
     fn from(src: &'a mut [u8]) -> Self {
+        assert!(src.len() > 0);
         unsafe {
             mem::transmute(libc::iovec {
                 iov_base: src.as_ptr() as *mut _,

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -29,6 +29,7 @@ impl IoVec {
 
 impl<'a> From<&'a [u8]> for &'a IoVec {
     fn from(src: &'a [u8]) -> Self {
+        assert!(src.len() > 0);
         assert!(src.len() <= MAX_LENGTH);
 
         unsafe {
@@ -42,6 +43,7 @@ impl<'a> From<&'a [u8]> for &'a IoVec {
 
 impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
     fn from(src: &'a mut [u8]) -> Self {
+        assert!(src.len() > 0);
         assert!(src.len() <= MAX_LENGTH);
 
         unsafe {


### PR DESCRIPTION
This commit is currently necessary to fix a soundness hole on Windows, and it's
also necessary to provide future compatibility for soundness holes on Unix.

This unsettling issue was first reported in #4. After some investigation I
think I understand why this is happening. Right now this crate sort of "abuses"
the compiler to get `&IoVec` and `&mut IoVec` to have the exact same in-memory
representation as the underlying networking buffers. To do this the type is
defined as `IoVec([u8])` (morally). The problem with this representation is
that we don't know where the pointer/length are in the two-word representation,
and on Unix/Windows it's different.

Now Rust in general must uphold the guarantee that the pointer part of `&[u8]`
is never null. This means that on one platform the pointer part of `&IoVec`
will actually be the data pointer, but on the other platform the pointer part
is actually the length (see the problem coming?). Turns out on Unix the current
representation of `&[u8]` aligns with the representation of `iovec`. On
Windows, however, the fields are swapped, where the pointer of `&[u8]` is the
length of `WSABUF`.

So what's happening here is that we're accidentally violating a language
guarantee. By creating a zero-length `WSABUF` we're effectively calling
`slice::from_raw_parts(ptr::null(), some_random_pointer as usize)`, and that's
undefined behavior!

This commit closes this soundness hole by adding asserts to both modules that
the slice lengths used here are always bigger than 0. This is, unfortunately,
a backwards incompatible change. It is, however, required for soundness on
Windows and future compatibility on Unix as we're not sure the slice
representation will stay the same.

Ideally this commit would also remove the `Default` implementations, but I've
opted for now to just go for behavior changes as opposed to API-breaking
changes.

Closes #4