### PR TITLE
Use a more reliable representation strategy.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,4 +181,10 @@ mod test {
         let buf: IoVecMut = (&mut buf[..]).into();
         assert_eq!(buf[..], b"hello world"[..]);
     }
+
+    #[test]
+    fn default() {
+        let buf: IoVec = IoVec::default();
+        assert_eq!(buf[..], b""[..]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,11 @@ impl<'a> IoVec<'a> {
         }
     }
 
+    /// Convert a slice of mutable iovecs to immutable iovecs
+    pub fn from_mut_slice<'b>(slice: &'b [IoVecMut<'a>]) -> &'b [Self] {
+        unsafe { ::std::mem::transmute(slice) }
+    }
+
     /// Immutable borrow of the iovec.
     pub fn borrow(&self) -> IoVec {
         IoVec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ extern crate winapi;
 
 mod sys;
 
-use std::{ops, mem};
+use std::ops;
+use std::marker::PhantomData;
 
 #[cfg(unix)]
 pub mod unix;
@@ -42,7 +43,7 @@ pub const MAX_LENGTH: usize = sys::MAX_LENGTH;
 /// let mut data = vec![];
 /// data.extend_from_slice(b"hello");
 ///
-/// let iovec: &IoVec = data.as_slice().into();
+/// let iovec: IoVec = data.as_slice().into();
 ///
 /// assert_eq!(&iovec[..], &b"hello"[..]);
 /// ```
@@ -53,45 +54,89 @@ pub const MAX_LENGTH: usize = sys::MAX_LENGTH;
 /// [`MAX_LENGTH`] to an `IoVec` will result in a panic.
 ///
 /// [`MAX_LENGTH`]: constant.MAX_LENGTH.html
-pub struct IoVec {
+pub struct IoVec<'a> {
     sys: sys::IoVec,
+    _p: PhantomData<&'a [u8]>,
 }
 
-impl IoVec {
-    pub fn from_bytes(slice: &[u8]) -> Option<&IoVec> {
-        if slice.len() == 0 {
-            return None
-        }
-        unsafe {
-            let iovec: &sys::IoVec = slice.into();
-            Some(mem::transmute(iovec))
+/// Mutable byte slice type for performing vectored I/O operations.
+pub struct IoVecMut<'a> {
+    sys: sys::IoVec,
+    _p: PhantomData<&'a mut [u8]>,
+}
+
+// ===== impl IoVec =====
+
+impl<'a> IoVec<'a> {
+    /// Convert an `IoVec` from a byte slice
+    pub fn from_bytes(slice: &[u8]) -> Self {
+        IoVec {
+            sys: sys::IoVec::from(slice),
+            _p: PhantomData,
         }
     }
 
-    pub fn from_bytes_mut(slice: &mut [u8]) -> Option<&mut IoVec> {
-        if slice.len() == 0 {
-            return None
+    /// Immutable borrow of the iovec.
+    pub fn borrow(&self) -> IoVec {
+        IoVec {
+            sys: self.sys.clone(),
+            _p: PhantomData,
         }
-        unsafe {
-            let iovec: &mut sys::IoVec = slice.into();
-            Some(mem::transmute(iovec))
-        }
-    }
-
-    #[deprecated(since = "0.1.0", note = "deref instead")]
-    #[doc(hidden)]
-    pub fn as_bytes(&self) -> &[u8] {
-        &**self
-    }
-
-    #[deprecated(since = "0.1.0", note = "deref instead")]
-    #[doc(hidden)]
-    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
-        &mut **self
     }
 }
 
-impl ops::Deref for IoVec {
+impl<'a> ops::Deref for IoVec<'a> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        self.sys.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for IoVec<'a> {
+    fn from(bytes: &'a [u8]) -> Self {
+        IoVec::from_bytes(bytes)
+    }
+}
+
+impl<'a> Default for IoVec<'a> {
+    fn default() -> Self {
+        IoVec {
+            sys: sys::IoVec::default(),
+            _p: PhantomData,
+        }
+    }
+}
+
+// ===== impl IoVecMut =====
+
+impl<'a> IoVecMut<'a> {
+    /// Convert an `IoVecMut` from a mutable byte slice.
+    pub fn from_bytes(slice: &mut [u8]) -> Self {
+        IoVecMut {
+            sys: sys::IoVec::from(slice),
+            _p: PhantomData,
+        }
+    }
+
+    /// Immutable borrow of the iovec.
+    pub fn borrow(&self) -> IoVec {
+        IoVec {
+            sys: self.sys.clone(),
+            _p: PhantomData,
+        }
+    }
+
+    /// Mutable borrow of the iovec.
+    pub fn borrow_mut(&mut self) -> IoVecMut {
+        IoVecMut {
+            sys: self.sys.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<'a> ops::Deref for IoVecMut<'a> {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
@@ -99,66 +144,41 @@ impl ops::Deref for IoVec {
     }
 }
 
-impl ops::DerefMut for IoVec {
+impl<'a> ops::DerefMut for IoVec<'a> {
     fn deref_mut(&mut self) -> &mut [u8] {
         self.sys.as_mut()
     }
 }
 
-#[doc(hidden)]
-impl<'a> From<&'a [u8]> for &'a IoVec {
-    fn from(bytes: &'a [u8]) -> &'a IoVec {
-        IoVec::from_bytes(bytes)
-            .expect("this crate accidentally accepted 0-sized slices \
-                     originally but this was since discovered as a soundness \
-                     hole, it's recommended to use the `from_bytes` \
-                     function instead")
+impl<'a> From<&'a mut [u8]> for IoVecMut<'a> {
+    fn from(bytes: &'a mut [u8]) -> Self {
+        IoVecMut::from_bytes(bytes)
     }
 }
 
-#[doc(hidden)]
-impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
-    fn from(bytes: &'a mut [u8]) -> &'a mut IoVec {
-        IoVec::from_bytes_mut(bytes)
-            .expect("this crate accidentally accepted 0-sized slices \
-                     originally but this was since discovered as a soundness \
-                     hole, it's recommended to use the `from_bytes_mut` \
-                     function instead")
-    }
-}
-
-#[doc(hidden)]
-impl<'a> Default for &'a IoVec {
+impl<'a> Default for IoVecMut<'a> {
     fn default() -> Self {
-        panic!("this implementation was accidentally provided but is \
-                unfortunately unsound, it's recommended to stop using \
-                `IoVec::default` or construct a vector with a nonzero length");
-    }
-}
-
-#[doc(hidden)]
-impl<'a> Default for &'a mut IoVec {
-    fn default() -> Self {
-        panic!("this implementation was accidentally provided but is \
-                unfortunately unsound, it's recommended to stop using \
-                `IoVec::default` or construct a vector with a nonzero length");
+        IoVecMut {
+            sys: sys::IoVec::default(),
+            _p: PhantomData,
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::IoVec;
+    use super::{IoVec, IoVecMut};
 
     #[test]
     fn convert_ref() {
-        let buf: &IoVec = (&b"hello world"[..]).into();
+        let buf: IoVec = (&b"hello world"[..]).into();
         assert_eq!(buf[..], b"hello world"[..]);
     }
 
     #[test]
     fn convert_mut() {
         let mut buf: Vec<u8> = b"hello world".to_vec();
-        let buf: &mut IoVec = (&mut buf[..]).into();
+        let buf: IoVecMut = (&mut buf[..]).into();
         assert_eq!(buf[..], b"hello world"[..]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,9 @@ pub struct IoVecMut<'a> {
 
 impl<'a> IoVec<'a> {
     /// Convert an `IoVec` from a byte slice
-    pub fn from_bytes(slice: &[u8]) -> Self {
+    pub fn from_bytes(slice: &'a [u8]) -> Self {
         IoVec {
-            sys: sys::IoVec::from(slice),
+            sys: unsafe { sys::IoVec::from_bytes(slice) },
             _p: PhantomData,
         }
     }
@@ -112,9 +112,9 @@ impl<'a> Default for IoVec<'a> {
 
 impl<'a> IoVecMut<'a> {
     /// Convert an `IoVecMut` from a mutable byte slice.
-    pub fn from_bytes(slice: &mut [u8]) -> Self {
+    pub fn from_bytes(slice: &'a mut [u8]) -> Self {
         IoVecMut {
-            sys: sys::IoVec::from(slice),
+            sys: unsafe { sys::IoVec::from_bytes_mut(slice) },
             _p: PhantomData,
         }
     }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -9,6 +9,24 @@ pub struct IoVec {
 pub const MAX_LENGTH: usize = usize::MAX;
 
 impl IoVec {
+    pub unsafe fn from_bytes(src: &[u8]) -> Self {
+        IoVec {
+            inner: libc::iovec {
+                iov_base: src.as_ptr() as *mut _,
+                iov_len: src.len(),
+            },
+        }
+    }
+
+    pub unsafe fn from_bytes_mut(src: &mut [u8]) -> Self {
+        IoVec {
+            inner: libc::iovec {
+                iov_base: src.as_ptr() as *mut _,
+                iov_len: src.len(),
+            },
+        }
+    }
+
     pub fn as_ref(&self) -> &[u8] {
         unsafe {
             slice::from_raw_parts(
@@ -26,30 +44,8 @@ impl IoVec {
     }
 }
 
-impl<'a> From<&'a [u8]> for IoVec {
-    fn from(src: &'a [u8]) -> Self {
-        IoVec {
-            inner: libc::iovec {
-                iov_base: src.as_ptr() as *mut _,
-                iov_len: src.len(),
-            },
-        }
-    }
-}
-
-impl<'a> From<&'a mut [u8]> for IoVec {
-    fn from(src: &'a mut [u8]) -> Self {
-        IoVec {
-            inner: libc::iovec {
-                iov_base: src.as_ptr() as *mut _,
-                iov_len: src.len(),
-            },
-        }
-    }
-}
-
 impl Default for IoVec {
     fn default() -> Self {
-        Self::from(<&[u8]>::default())
+        unsafe { Self::from_bytes(<&[u8]>::default()) }
     }
 }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -1,5 +1,5 @@
 use winapi::{WSABUF, DWORD};
-use std::{mem, slice, u32};
+use std::{slice, u32};
 
 #[derive(Clone)]
 pub struct IoVec {
@@ -9,6 +9,24 @@ pub struct IoVec {
 pub const MAX_LENGTH: usize = u32::MAX as usize;
 
 impl IoVec {
+    pub unsafe fn from_bytes(src: &[u8]) -> Self {
+        IoVec {
+            inner: WSABUF {
+                buf: src.as_ptr() as *mut _,
+                len: src.len() as DWORD,
+            }
+        }
+    }
+
+    pub unsafe fn from_bytes_mut(src: &mut [u8]) -> Self {
+        IoVec {
+            inner: WSABUF {
+                buf: src.as_ptr() as *mut _,
+                len: src.len() as DWORD,
+            }
+        }
+    }
+
     pub fn as_ref(&self) -> &[u8] {
         unsafe {
             slice::from_raw_parts(
@@ -26,30 +44,8 @@ impl IoVec {
     }
 }
 
-impl<'a> From<&'a [u8]> for IoVec {
-    fn from(src: &'a [u8]) -> Self {
-        IoVec {
-            inner: WSABUF {
-                buf: src.as_ptr() as *mut _,
-                len: src.len() as DWORD,
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a mut [u8]> for IoVec {
-    fn from(src: &'a mut [u8]) -> Self {
-        IoVec {
-            inner: WSABUF {
-                buf: src.as_ptr() as *mut _,
-                len: src.len() as DWORD,
-            }
-        }
-    }
-}
-
 impl Default for IoVec {
     fn default() -> Self {
-        Self::from(<&[u8]>::default())
+        unsafe { Self::from_bytes(<&[u8]>::default()) }
     }
 }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -1,8 +1,9 @@
 use winapi::{WSABUF, DWORD};
 use std::{mem, slice, u32};
 
+#[derive(Clone)]
 pub struct IoVec {
-    inner: [u8],
+    inner: WSABUF,
 }
 
 pub const MAX_LENGTH: usize = u32::MAX as usize;
@@ -10,47 +11,45 @@ pub const MAX_LENGTH: usize = u32::MAX as usize;
 impl IoVec {
     pub fn as_ref(&self) -> &[u8] {
         unsafe {
-            let vec = self.wsabuf();
-            slice::from_raw_parts(vec.buf as *const u8, vec.len as usize)
+            slice::from_raw_parts(
+                self.inner.buf as *const u8,
+                self.inner.len as usize)
         }
     }
 
     pub fn as_mut(&mut self) -> &mut [u8] {
         unsafe {
-            let vec = self.wsabuf();
-            slice::from_raw_parts_mut(vec.buf as *mut u8, vec.len as usize)
+            slice::from_raw_parts_mut(
+                self.inner.buf as *mut u8,
+                self.inner.len as usize)
         }
-    }
-
-    unsafe fn wsabuf(&self) -> WSABUF {
-        mem::transmute(&self.inner)
     }
 }
 
-impl<'a> From<&'a [u8]> for &'a IoVec {
+impl<'a> From<&'a [u8]> for IoVec {
     fn from(src: &'a [u8]) -> Self {
-        assert!(src.len() > 0);
-        assert!(src.len() <= MAX_LENGTH);
-
-        unsafe {
-            mem::transmute(WSABUF {
+        IoVec {
+            inner: WSABUF {
                 buf: src.as_ptr() as *mut _,
                 len: src.len() as DWORD,
-            })
+            }
         }
     }
 }
 
-impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
+impl<'a> From<&'a mut [u8]> for IoVec {
     fn from(src: &'a mut [u8]) -> Self {
-        assert!(src.len() > 0);
-        assert!(src.len() <= MAX_LENGTH);
-
-        unsafe {
-            mem::transmute(WSABUF {
+        IoVec {
+            inner: WSABUF {
                 buf: src.as_ptr() as *mut _,
                 len: src.len() as DWORD,
-            })
+            }
         }
+    }
+}
+
+impl Default for IoVec {
+    fn default() -> Self {
+        Self::from(<&[u8]>::default())
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -12,13 +12,13 @@
 //! let a = b"hello".to_vec();
 //! let b = b"world".to_vec();
 //!
-//! let bufs: &[&IoVec] = &[(&a[..]).into(), (&b[..]).into()];
+//! let bufs: &[IoVec] = &[(&a[..]).into(), (&b[..]).into()];
 //! let os_bufs = unix::as_os_slice(&bufs[..]);
 //!
 //! // Use the `os_bufs` slice with `writev`.
 //! ```
 
-use IoVec;
+use {IoVec, IoVecMut};
 use libc;
 
 use std::mem;
@@ -36,12 +36,12 @@ use std::mem;
 /// let a = b"hello".to_vec();
 /// let b = b"world".to_vec();
 ///
-/// let bufs: &[&IoVec] = &[a[..].into(), b[..].into()];
+/// let bufs: &[IoVec] = &[a[..].into(), b[..].into()];
 /// let os_bufs = unix::as_os_slice(bufs);
 ///
 /// // Use the `os_bufs` slice with `writev`.
 /// ```
-pub fn as_os_slice<'a>(iov: &'a [&IoVec]) -> &'a [libc::iovec] {
+pub fn as_os_slice<'a>(iov: &'a [IoVec]) -> &'a [libc::iovec] {
     unsafe { mem::transmute(iov) }
 }
 
@@ -52,17 +52,17 @@ pub fn as_os_slice<'a>(iov: &'a [&IoVec]) -> &'a [libc::iovec] {
 /// # Examples
 ///
 /// ```
-/// use iovec::IoVec;
+/// use iovec::IoVecMut;
 /// use iovec::unix;
 ///
 /// let mut a = [0; 10];
 /// let mut b = [0; 10];
 ///
-/// let bufs: &mut [&mut IoVec] = &mut [(&mut a[..]).into(), (&mut b[..]).into()];
+/// let bufs: &mut [IoVecMut] = &mut [(&mut a[..]).into(), (&mut b[..]).into()];
 /// let os_bufs = unix::as_os_slice_mut(bufs);
 ///
 /// // Use the `os_bufs` slice with `readv`.
 /// ```
-pub fn as_os_slice_mut<'a>(iov: &'a mut [&mut IoVec]) -> &'a mut [libc::iovec] {
+pub fn as_os_slice_mut<'a>(iov: &'a mut [IoVecMut]) -> &'a mut [libc::iovec] {
     unsafe { mem::transmute(iov) }
 }


### PR DESCRIPTION
This is a permanent fix for the issue originally resolved by #5. The
commit introduces a new representation for `IoVec` that does not rely on
DST internals. This should provide more long term stability.