### PR TITLE
Add support for non-windows/unix targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,20 @@ matrix:
     - os: linux
       # Oldest supported Rust (this should track Mio)
       rust: 1.9.0
+    - os: linux
+      # Verify WebAssembly support.  As of right now the target is only
+      # available on nightly.
+      rust: nightly
+      env: [TARGET=wasm32-unknown-unknown]
 
 script:
-  - cargo build
-  - cargo test
+  - |
+      if [ -n "$TARGET" ]
+      then rustup target add "$TARGET"
+           CARGO_FLAGS="--target=$TARGET"
+      fi
+  - cargo build $CARGO_FLAGS
+  - cargo test $CARGO_FLAGS
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,23 @@
 language: rust
 sudo: false
 
-rust:
-  - stable
-
-os:
-  - linux
-  - osx
-
 matrix:
   include:
-    - os: linux
-      # Oldest supported Rust (this should track Mio)
-      rust: 1.9.0
-    - os: linux
-      # Verify WebAssembly support.  As of right now the target is only
-      # available on nightly.
-      rust: nightly
-      env: [TARGET=wasm32-unknown-unknown, TEST=false]
+    # Oldest supported Rust (this should track Mio)
+    - rust: 1.9.0
+    - rust: stable
+    # OS X support
+    - rust: stable
+      os: osx
+    # WebAssembly support.
+    - rust: beta
+      script:
+        - rustup target add wasm32-unknown-unknown
+        - cargo build --target=wasm32-unknown-unknown
 
 script:
-  - |
-      if [ -n "$TARGET" ]
-      then rustup target add "$TARGET"
-           CARGO_FLAGS="--target=$TARGET"
-      fi
-  - cargo build $CARGO_FLAGS
-  - |
-      if [ "$TEST" != false ]
-      then cargo test $CARGO_FLAGS
-      fi
+  - cargo build
+  - cargo test
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       # Verify WebAssembly support.  As of right now the target is only
       # available on nightly.
       rust: nightly
-      env: [TARGET=wasm32-unknown-unknown]
+      env: [TARGET=wasm32-unknown-unknown, TEST=false]
 
 script:
   - |
@@ -27,7 +27,10 @@ script:
            CARGO_FLAGS="--target=$TARGET"
       fi
   - cargo build $CARGO_FLAGS
-  - cargo test $CARGO_FLAGS
+  - |
+      if [ "$TEST" != false ]
+      then cargo test $CARGO_FLAGS
+      fi
 
 notifications:
   email:

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -15,3 +15,12 @@ pub use self::windows::{
     IoVec,
     MAX_LENGTH,
 };
+
+#[cfg(not(any(windows, unix)))]
+mod unknown;
+
+#[cfg(not(any(windows, unix)))]
+pub use self::unknown::{
+    IoVec,
+    MAX_LENGTH,
+};

--- a/src/sys/unknown.rs
+++ b/src/sys/unknown.rs
@@ -1,32 +1,40 @@
-use std::mem;
+use std::slice;
 use std::usize;
 
+#[derive(Clone)]
 pub struct IoVec {
-    inner: [u8],
+    ptr: *const u8,
+    len: usize,
 }
 
 pub const MAX_LENGTH: usize = usize::MAX;
 
 impl IoVec {
+    pub unsafe fn from_bytes(src: &[u8]) -> Self {
+        IoVec {
+            ptr: src.as_ptr(),
+            len: src.len(),
+        }
+    }
+
+    pub unsafe fn from_bytes_mut(src: &mut [u8]) -> Self {
+        IoVec {
+            ptr: src.as_ptr(),
+            len: src.len(),
+        }
+    }
+
     pub fn as_ref(&self) -> &[u8] {
-        &self.inner
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
     }
 
     pub fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.inner
+        unsafe { slice::from_raw_parts_mut(self.ptr as *mut u8, self.len) }
     }
 }
 
-impl<'a> From<&'a [u8]> for &'a IoVec {
-    fn from(src: &'a [u8]) -> Self {
-        assert!(src.len() > 0);
-        unsafe { mem::transmute(src) }
-    }
-}
-
-impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
-    fn from(src: &'a mut [u8]) -> Self {
-        assert!(src.len() > 0);
-        unsafe { mem::transmute(src) }
+impl Default for IoVec {
+    fn default() -> Self {
+        unsafe { Self::from_bytes(<&[u8]>::default()) }
     }
 }

--- a/src/sys/unknown.rs
+++ b/src/sys/unknown.rs
@@ -1,0 +1,32 @@
+use std::mem;
+use std::usize;
+
+pub struct IoVec {
+    inner: [u8],
+}
+
+pub const MAX_LENGTH: usize = usize::MAX;
+
+impl IoVec {
+    pub fn as_ref(&self) -> &[u8] {
+        &self.inner
+    }
+
+    pub fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.inner
+    }
+}
+
+impl<'a> From<&'a [u8]> for &'a IoVec {
+    fn from(src: &'a [u8]) -> Self {
+        assert!(src.len() > 0);
+        unsafe { mem::transmute(src) }
+    }
+}
+
+impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
+    fn from(src: &'a mut [u8]) -> Self {
+        assert!(src.len() > 0);
+        unsafe { mem::transmute(src) }
+    }
+}


### PR DESCRIPTION
This is mostly for wasm support and I'm not sure if this approach is great for other targets.

I could also add a continuous integration job for this target if necessary.