### PR TITLE
migrate to winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ categories = ["network-programming", "api-bindings"]
 libc   = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
+winapi = { version = "0.3", features = ["minwindef", "ws2def"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ impl<'a> ops::Deref for IoVecMut<'a> {
     }
 }
 
-impl<'a> ops::DerefMut for IoVec<'a> {
+impl<'a> ops::DerefMut for IoVecMut<'a> {
     fn deref_mut(&mut self) -> &mut [u8] {
         self.sys.as_mut()
     }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -1,4 +1,5 @@
-use winapi::{WSABUF, DWORD};
+use winapi::shared::minwindef::DWORD;
+use winapi::shared::ws2def::WSABUF;
 use std::{slice, u32};
 
 #[derive(Clone)]


### PR DESCRIPTION
This updates to winapi 0.3 and should improve compilation times.
This should be fine to merge as is due to the minimal nature.
