### PR TITLE
Fix undefined behavior when transmuting slices.

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -21,8 +21,6 @@
 use {IoVec, IoVecMut};
 use libc;
 
-use core::mem;
-
 /// Convert a slice of `IoVec` refs to a slice of `libc::iovec`.
 ///
 /// The return value can be passed to `writev` bindings.
@@ -42,7 +40,7 @@ use core::mem;
 /// // Use the `os_bufs` slice with `writev`.
 /// ```
 pub fn as_os_slice<'a>(iov: &'a [IoVec]) -> &'a [libc::iovec] {
-    unsafe { mem::transmute(iov) }
+    unsafe { ::transmute_slice(iov) }
 }
 
 /// Convert a mutable slice of `IoVec` refs to a mutable slice of `libc::iovec`.
@@ -64,5 +62,5 @@ pub fn as_os_slice<'a>(iov: &'a [IoVec]) -> &'a [libc::iovec] {
 /// // Use the `os_bufs` slice with `readv`.
 /// ```
 pub fn as_os_slice_mut<'a>(iov: &'a mut [IoVecMut]) -> &'a mut [libc::iovec] {
-    unsafe { mem::transmute(iov) }
+    unsafe { ::transmute_mut_slice(iov) }
 }


### PR DESCRIPTION
The representation of slices is unspecified meaning that a mem::transmute is not
guaranteed to do the right thing although it currently does in practice so AFAICT
this currently is not a security vulnerability.

The fix is "simple": instead of transmuting the slices, we get the pointer and
the length of a slice, and use `from_raw_parts` to construct the other by
casting the pointer to the other pointer type. For this to work correctly, both
types have to have the same size, since otherwise, the length of the first slice
would be incorrect. Also, either both types have the same alignment, or the
original pointer is suitably aligned for the second type. Since the types here
are fixed and internal to the library, we assert these conditions using
`debug_assert!`s only. As long as these transmutes are tested, any changes in
layout that would introduce undefined behavior will be detected.