### PR TITLE
Backport winapi 0.3 to v0.1.x branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3 (xxx)
+
+* Backport winapi 0.3 to 0.1.x branch (#19)
+
 # 0.1.2 (January 26th, 2018)
 
 * Add support for non-windows/unix targets (#10)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iovec"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ categories = ["network-programming", "api-bindings"]
 libc   = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
+winapi = { version = "0.3", features = ["minwindef", "ws2def"] }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -1,4 +1,5 @@
-use winapi::{WSABUF, DWORD};
+use winapi::shared::minwindef::DWORD;
+use winapi::shared::ws2def::WSABUF;
 use std::{mem, slice, u32};
 
 pub struct IoVec {


### PR DESCRIPTION
fixes #16.

I understand your concerns about iovec 0.2, but nothing prevents you from releasing this patch update for iovec 0.1.