### PR TITLE
Remove dependency on winapi 0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 matrix:
   include:
     # Oldest supported Rust (this should track Mio)
-    - rust: 1.9.0
+    - rust: 1.18.0
     - rust: stable
     # OS X support
     - rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3 (September 20th, 2019)
+
+* Remove dependency on old winapi 0.2 (#16)
+
 # 0.1.2 (January 26th, 2018)
 
 * Add support for non-windows/unix targets (#10)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iovec"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -15,6 +15,3 @@ categories = ["network-programming", "api-bindings"]
 
 [target.'cfg(unix)'.dependencies]
 libc   = "0.2"
-
-[target.'cfg(windows)'.dependencies]
-winapi = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,6 @@
 #[cfg(unix)]
 extern crate libc;
 
-#[cfg(windows)]
-extern crate winapi;
-
 mod sys;
 
 use std::{ops, mem};

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -1,5 +1,16 @@
-use winapi::{WSABUF, DWORD};
 use std::{mem, slice, u32};
+
+// declare the types we need directly here to avoid bringing
+// in the old and slow winapi 0.2 dependency.
+
+type DWORD = u32;
+type ULONG = u32;
+type CHAR = i8;
+
+struct WSABUF {
+    pub len: ULONG,
+    pub buf: *mut CHAR,
+}
 
 pub struct IoVec {
     inner: [u8],


### PR DESCRIPTION
Instead declare the few types we use directly in the crate to avoid bringing in the old `winapi 0.2` crate.

Fixes #16.
Replaces previous attempts #19 #22 #24.