### PR TITLE
libc: require 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ Portable buffer type for scatter/gather I/O operations
 categories = ["network-programming", "api-bindings"]
 
 [target.'cfg(unix)'.dependencies]
-libc   = "0.2"
+libc   = "0.2.3"


### PR DESCRIPTION
This version introduced the iovec calls.